### PR TITLE
feat: Initial Dockerization of the Django application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ db.sqlite3
 db.sqlite3-journal
 /media
 /static
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Use python:slim as the base image
+FROM python:slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set up a working directory
+WORKDIR /app
+
+# Copy requirements.txt and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose port 8000
+EXPOSE 8000
+
+# Set the command to run Gunicorn
+CMD ["gunicorn", "boardgame_timer.wsgi:application", "--bind", "0.0.0.0:8000"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: gunicorn boardgame_timer.wsgi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+
+services:
+  web:
+    build: .
+    # The command from the Dockerfile will be used:
+    # gunicorn boardgame_timer.wsgi:application --bind 0.0.0.0:8000
+    volumes:
+      - .:/app  # Mounts the current directory to /app in the container
+      # This ensures that if db.sqlite3 is created in /app, it's persisted
+      # via the host bind mount. For more explicit control over the db file,
+      # we can map a named volume directly to the db file.
+      # Django's default DATABASES setting will place db.sqlite3 in BASE_DIR (which is /app).
+      # So, .:/app covers it.
+      # If we want to ensure the db is in a separate volume, independent of the code mount:
+      # We would need to adjust settings.py to point DATABASES['default']['NAME'] to e.g. /app/data/db.sqlite3
+      # and then mount a volume to /app/data.
+      # For now, relying on .:/app to persist db.sqlite3 at /app/db.sqlite3 is the simplest.
+      # To be more robust and avoid the db file being part of the general code mount,
+      # let's use a named volume for the database file specifically.
+      # This also means if you blow away your local code, the db in the named volume persists.
+      - sqlite_volume:/app/db.sqlite3
+    ports:
+      - "8000:8000"
+    # Add environment variables if needed for Django settings, e.g., SECRET_KEY
+    # environment:
+    #   - SECRET_KEY=${SECRET_KEY}
+    #   - DEBUG=${DEBUG}
+
+volumes:
+  sqlite_volume: # Persists the SQLite database


### PR DESCRIPTION
This commit introduces the initial setup for Dockerizing the Django application.

Changes include:
- Removal of Heroku-specific file (`Procfile`).
- Creation of a `Dockerfile` using `python:slim` and Gunicorn.
- Creation of a `docker-compose.yml` for local deployment, configured to use the Dockerfile and persist an SQLite database using a named volume.
- Update of `.gitignore` to include `.dockerignore`.
- Creation of a `.dockerignore` file to exclude unnecessary files from the Docker image build context.

Next steps that I planned:
1. Add `RUN python manage.py collectstatic --noinput --clear` to the `Dockerfile` to ensure static files are properly handled by WhiteNoise.

Further investigation required based on your feedback:
- Verify if the Django application actually uses a database. The current setup assumes SQLite usage and includes persistence for `db.sqlite3`. If no database is used, the `DATABASES` setting in `settings.py` should be checked, and `docker-compose.yml` (volume for sqlite_db) and `.dockerignore` (ignoring db.sqlite3) should be simplified accordingly.